### PR TITLE
Policy macro can be configured with actor key

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,7 +113,23 @@ Enhanced policy handling for use with Hubbado::Policy:
 
 ```ruby
 class Users::Update < Trailblazer::Operation
-  step Hubbado::Trailblazer::Macro::Policy(Users::UpdatePolicy)
+  step Hubbado::Trailblazer::Macro::Policy(Users::UpdatePolicy, :update)
+  # ... other steps
+end
+```
+
+Can also configure model key context, default to `:model`
+```ruby
+class Users::Update < Trailblazer::Operation
+  step Hubbado::Trailblazer::Macro::Policy(Users::UpdatePolicy, :update, model: :user)
+  # ... other steps
+end
+```
+
+Can also configure actor key context, default to `:current_user`
+```ruby
+class Users::Update < Trailblazer::Operation
+  step Hubbado::Trailblazer::Macro::Policy(Users::UpdatePolicy, :update, actor: :current_account)
   # ... other steps
 end
 ```

--- a/lib/hubbado/trailblazer/macro/policy.rb
+++ b/lib/hubbado/trailblazer/macro/policy.rb
@@ -1,23 +1,24 @@
 module Hubbado
   module Trailblazer
     module Macro
-      def self.Policy(policy_class, action, name: :default, model: :model)
+      def self.Policy(policy_class, action, name: :default, model: :model, actor: :current_user)
         ::Trailblazer::Macro::Policy.step(
-          Policy.build(policy_class, action, model), name: name
+          Policy.build(policy_class, action, model, actor), name: name
         )
       end
 
       module Policy
-        def self.build(policy_class, action, model)
-          Condition.new(policy_class, action, model)
+        def self.build(policy_class, action, model, actor)
+          Condition.new(policy_class, action, model, actor)
         end
 
         # Pundit::Condition is invoked at runtime when iterating the pipe.
         class Condition
-          def initialize(policy_class, action, model)
+          def initialize(policy_class, action, model, actor)
             @policy_class = policy_class
             @action = action
             @model = model
+            @actor = actor
           end
 
           # Instantiate the actual policy object, and call it.
@@ -29,7 +30,7 @@ module Hubbado
           private
 
           def build_policy(options)
-            @policy_class.build(options[:current_user], options[@model])
+            @policy_class.build(options[@actor], options[@model])
           end
 
           def result!(policy_result, policy)

--- a/test/automated/hubbado/trailblazer/macro/policy.rb
+++ b/test/automated/hubbado/trailblazer/macro/policy.rb
@@ -26,7 +26,9 @@ context "Hubbado" do
 
         context "Build" do
           test "returns a Condition instance" do
-            condition = Hubbado::Trailblazer::Macro::Policy.build(PolicyKlass, :show, :model)
+            condition = Hubbado::Trailblazer::Macro::Policy.build(
+              PolicyKlass, :show, :model, :current_user
+            )
 
             assert condition.class == Hubbado::Trailblazer::Macro::Policy::Condition
           end

--- a/test/support/active_record.rb
+++ b/test/support/active_record.rb
@@ -8,9 +8,11 @@ ActiveRecord::Base.establish_connection(
 
 ActiveRecord::Base.logger = Logger.new(STDOUT) if ENV['DEBUG']
 
-ActiveRecord::Schema.define do
-  create_table :users do |t|
-    t.string :name, null: false
+ActiveRecord::Migration.suppress_messages do
+  ActiveRecord::Schema.define do
+    create_table :users do |t|
+      t.string :name, null: false
+    end
   end
 end
 


### PR DESCRIPTION
Usually current_user is what we have but we could have a different kind of actor, like an account, so we could configure it like `actor: current_account`